### PR TITLE
 Fork velero chart and make modifications to work with GitOps

### DIFF
--- a/charts/velero/crds/backups.yaml
+++ b/charts/velero/crds/backups.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: backups.velero.io

--- a/charts/velero/crds/backupstoragelocations.yaml
+++ b/charts/velero/crds/backupstoragelocations.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: backupstoragelocations.velero.io

--- a/charts/velero/crds/deletebackuprequests.yaml
+++ b/charts/velero/crds/deletebackuprequests.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: deletebackuprequests.velero.io

--- a/charts/velero/crds/downloadrequests.yaml
+++ b/charts/velero/crds/downloadrequests.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: downloadrequests.velero.io

--- a/charts/velero/crds/podvolumebackups.yaml
+++ b/charts/velero/crds/podvolumebackups.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podvolumebackups.velero.io

--- a/charts/velero/crds/podvolumerestores.yaml
+++ b/charts/velero/crds/podvolumerestores.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podvolumerestores.velero.io

--- a/charts/velero/crds/resticrepositories.yaml
+++ b/charts/velero/crds/resticrepositories.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: resticrepositories.velero.io

--- a/charts/velero/crds/restores.yaml
+++ b/charts/velero/crds/restores.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: velero
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: restores.velero.io

--- a/charts/velero/crds/schedules.yaml
+++ b/charts/velero/crds/schedules.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,post-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: schedules.velero.io

--- a/charts/velero/crds/serverstatusrequests.yaml
+++ b/charts/velero/crds/serverstatusrequests.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: serverstatusrequests.velero.io

--- a/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/charts/velero/crds/volumesnapshotlocations.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: "velero"
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: volumesnapshotlocations.velero.io

--- a/charts/velero/templates/backupstoragelocation.yaml
+++ b/charts/velero/templates/backupstoragelocation.yaml
@@ -4,8 +4,6 @@ kind: BackupStorageLocation
 metadata:
   name: {{ include "velero.backupStorageLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/cleanup-crd.yaml
+++ b/charts/velero/templates/cleanup-crd.yaml
@@ -7,9 +7,6 @@ metadata:
   name: {{ template "velero.fullname" . }}-cleanup
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/charts/velero/templates/volumesnapshotlocation.yaml
@@ -4,8 +4,6 @@ kind: VolumeSnapshotLocation
 metadata:
   name: {{ include "velero.volumeSnapshotLocation.name" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/ezREADME.md
+++ b/ezREADME.md
@@ -1,0 +1,28 @@
+# Slightly Modified Velero Chart
+
+For use with GitOps and ArgoCD.
+
+Helm isn't great with CRDs in general, so Velero uses hooks to manage them to support both Helm v2 and Helm v3. Unfortunately, hooks are not considered permanent resources, so ArgoCD wants to recreate them all the time.
+
+To avoid this from happening, we have forked the chart, and we remove all Helm hooks from CRDs and CRs.
+
+Relevant Issues:
+
+- https://github.com/vmware-tanzu/helm-charts/issues/158
+- https://github.com/vmware-tanzu/helm-charts/issues/44
+
+# How to Generate this Chart
+
+If we need to bump the version of this chart, we need to clear out the helm hooks from `main`.
+
+1. Check the status of those two issues linked above. If the maintainers have implemented a proper fix for this, we may be able to use the chart as-is and not fork it.
+2. Rebase `main` off of `upstream/main`: `git fetch upstream && rebase upstream/main`. If this results in conflicts, resolve them before continuing. When in doubt, remember: the end goal is for the helm hooks to be gone.
+3. Remove all instances of `helm.sh/hook`:
+
+```
+sed -i'' '/helm.sh\/hook/d' charts/velero/crds/*
+sed -i'' '/helm.sh\/hook/d' charts/velero/templates/*
+```
+
+5. Double check that the only files that changed are the CRDs in the `crds/` directory, and two CRs: backupstoragelocation and volumesnapshotlocation.
+6. Commit and PR against ezcater/vmware-helm-charts.

--- a/ezREADME.md
+++ b/ezREADME.md
@@ -31,4 +31,4 @@ sed -i'' '/helm.sh\/hook/d' charts/velero/templates/*
 ```
 
 5. Double check that the only files that changed are the CRDs in the `crds/` directory, and two CRs: backupstoragelocation and volumesnapshotlocation.
-6. Commit and PR against ezcater/vmware-helm-charts. Don't open a PR against the upstream repo!
+6. Commit and PR against ezcater/vmware-tanzu-helm-charts. Don't open a PR against the upstream repo!

--- a/ezREADME.md
+++ b/ezREADME.md
@@ -25,4 +25,4 @@ sed -i'' '/helm.sh\/hook/d' charts/velero/templates/*
 ```
 
 5. Double check that the only files that changed are the CRDs in the `crds/` directory, and two CRs: backupstoragelocation and volumesnapshotlocation.
-6. Commit and PR against ezcater/vmware-helm-charts.
+6. Commit and PR against ezcater/vmware-helm-charts. Don't open a PR against the upstream repo!

--- a/ezREADME.md
+++ b/ezREADME.md
@@ -13,6 +13,12 @@ Relevant Issues:
 
 # How to Generate this Chart
 
+First: add the upstream chart as an additional remote named `upstream`:
+
+```
+git remote add upstream git@github.com:vmware-tanzu/helm-charts.git
+```
+
 If we need to bump the version of this chart, we need to clear out the helm hooks from `main`.
 
 1. Check the status of those two issues linked above. If the maintainers have implemented a proper fix for this, we may be able to use the chart as-is and not fork it.


### PR DESCRIPTION
Moved https://github.com/ezcater/helm-charts/pull/1 into new proper fork of https://github.com/vmware-tanzu/helm-charts, for use with ArgoCD.


